### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete string escaping or encoding

### DIFF
--- a/src/services/declarative-rules/processors/DomainRuleProcessor.ts
+++ b/src/services/declarative-rules/processors/DomainRuleProcessor.ts
@@ -170,7 +170,7 @@ export class DomainRuleProcessor extends BaseProcessor {
 
       for (const domain of domainGroup) {
         // Escape dots in domain name for regex
-        const escapedDomain = domain.replace(/\./g, '\\.');
+        const escapedDomain = domain.replace(/([\\\.])/g, '\\$1');
 
         // Check if adding this domain would exceed the regex length limit
         if (currentPattern.length + escapedDomain.length + 1 > this.maxRegexLength) {


### PR DESCRIPTION
Potential fix for [https://github.com/veto-firewall/veto/security/code-scanning/4](https://github.com/veto-firewall/veto/security/code-scanning/4)

To fix the issue, the `domain.replace` operation should be updated to escape both backslashes (`\`) and dots (`.`) in the input string. This can be achieved by using a regular expression that matches both characters and replaces them with their escaped versions. Specifically, the replacement should handle backslashes first to avoid double-escaping issues.

The best approach is to use a well-tested sanitization library for escaping strings for regex purposes. However, if such a library is not available or feasible, the code can be updated to use a regular expression that escapes both backslashes and dots globally.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
